### PR TITLE
fixed multi-statement queries for libsql databases

### DIFF
--- a/src/database_drivers/sqlite.rs
+++ b/src/database_drivers/sqlite.rs
@@ -39,7 +39,14 @@ impl DatabaseDriver for SqliteDriver {
         query: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), anyhow::Error>> + '_>> {
         let fut = async move {
-            self.db.execute(query)?;
+            let queries = query
+                .split(";")
+                .map(|x| x.trim())
+                .filter(|x| !x.is_empty())
+                .collect::<Vec<&str>>();
+            for query in queries {
+                self.db.execute(query)?;
+            }
             Ok(())
         };
 

--- a/src/integration_test.rs
+++ b/src/integration_test.rs
@@ -18,7 +18,7 @@ mod tests {
         let file_endings = vec!["up", "down"];
         let test_queries = [
             (
-                "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);",
+                "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL); CREATE TABLE computers (id INTEGER PRIMARY KEY, name TEXT NOT NULL); ;",
                 "DROP TABLE users;",
             ),
             (


### PR DESCRIPTION
We got a issue #29 which reported that multi statements don't work. This PR fixes this issue and also improve the tests by adding a empty sql query and multi-statements queries to the integration_test.

Fixes #29 