### PR TITLE
Fix issue with not all tables are printed in schema.sql

### DIFF
--- a/src/lib/database_drivers/libsql.rs
+++ b/src/lib/database_drivers/libsql.rs
@@ -196,10 +196,7 @@ impl DatabaseDriver for LibSQLDriver {
                             .to_string()
                             .replace("\\n", "\n"),
                     );
-                    continue;
                 }
-
-                break;
             }
 
             let final_schema = schemas.join("\n");

--- a/src/lib/database_drivers/sqlite.rs
+++ b/src/lib/database_drivers/sqlite.rs
@@ -176,10 +176,7 @@ impl DatabaseDriver for SqliteDriver {
                             .to_string()
                             .replace("\\n", "\n"),
                     );
-                    continue;
                 }
-
-                break;
             }
 
             let final_schema = schemas.join("\n");


### PR DESCRIPTION
This pr fixes a issue where schema.sql only printed the first item in  `sqlite_master` table so the rest of tables wasn't added


Fixes #129 