### PR TITLE
Added ; separator to schema.sql output from `sqlite_master`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "geni"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geni"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2021"
 resolver = "2"
 description = "A standalone database CLI migration tool"

--- a/src/lib/database_drivers/libsql.rs
+++ b/src/lib/database_drivers/libsql.rs
@@ -201,13 +201,13 @@ impl DatabaseDriver for LibSQLDriver {
             let mut schemas: Vec<String> = vec![];
             while let Some(row) = result.next().await.unwrap_or(None) {
                 if let Ok(r) = row.get_str(0) {
-                    schemas.push(
-                        r.to_string()
-                            .trim_start_matches('"')
-                            .trim_end_matches('"')
-                            .to_string()
-                            .replace("\\n", "\n"),
-                    );
+                    let text = r
+                        .to_string()
+                        .trim_start_matches('"')
+                        .trim_end_matches('"')
+                        .to_string()
+                        .replace("\\n", "\n");
+                    schemas.push(format!("{};", text));
                 }
             }
 

--- a/src/lib/database_drivers/sqlite.rs
+++ b/src/lib/database_drivers/sqlite.rs
@@ -181,13 +181,13 @@ impl DatabaseDriver for SqliteDriver {
             let mut schemas: Vec<String> = vec![];
             while let Some(row) = result.next().await.unwrap_or(None) {
                 if let Ok(r) = row.get_str(0) {
-                    schemas.push(
-                        r.to_string()
-                            .trim_start_matches('"')
-                            .trim_end_matches('"')
-                            .to_string()
-                            .replace("\\n", "\n"),
-                    );
+                    let text = r
+                        .to_string()
+                        .trim_start_matches('"')
+                        .trim_end_matches('"')
+                        .to_string()
+                        .replace("\\n", "\n");
+                    schemas.push(format!("{};", text));
                 }
             }
 


### PR DESCRIPTION
This PRs adds a `;` to the end of sqlite "commands" when we dump the database.

Closes #185
