### PR TITLE
Improve the output of dump for postgres, maria and mysql

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1327,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "geni"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geni"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 resolver = "2"
 description = "A standalone database CLI migration tool"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,8 @@ testcontainers = "0.27.2"
 serial_test = "3.2.0"
 
 [profile.release]
-opt-level = 'z'     # Optimize for size
-lto = true          # Enable link-time optimization
-codegen-units = 1   # Reduce number of codegen units to increase optimizations
-panic = 'abort'     # Abort on panic
-strip = true        # Strip symbols from binary*
+opt-level = 'z'     
+lto = true         
+codegen-units = 1  
+panic = 'abort'   
+strip = true     

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 10

--- a/src/bin/geni/tunnel.rs
+++ b/src/bin/geni/tunnel.rs
@@ -663,7 +663,10 @@ mod tests {
 
         assert_eq!(
             tunnel.database_url,
-            format!("postgres://user:secret@127.0.0.1:{}/app?sslmode=disable", test_port)
+            format!(
+                "postgres://user:secret@127.0.0.1:{}/app?sslmode=disable",
+                test_port
+            )
         );
 
         let args = fs::read_to_string(&args_path)?;
@@ -795,7 +798,10 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            format!("requested SSH tunnel local port {} is already in use", test_port)
+            format!(
+                "requested SSH tunnel local port {} is already in use",
+                test_port
+            )
         );
 
         Ok(())

--- a/src/lib/database_drivers/libsql.rs
+++ b/src/lib/database_drivers/libsql.rs
@@ -88,11 +88,7 @@ impl DatabaseDriver for LibSQLDriver {
             let mut result = self
                 .db
                 .query(
-                    format!(
-                        " SELECT id FROM {} ORDER BY id DESC;",
-                        table
-                    )
-                    .as_str(),
+                    format!(" SELECT id FROM {} ORDER BY id DESC;", table).as_str(),
                     params![],
                 )
                 .await?;

--- a/src/lib/database_drivers/libsql.rs
+++ b/src/lib/database_drivers/libsql.rs
@@ -14,9 +14,9 @@ pub struct LibSQLDriver {
     schema_file: String,
 }
 
-impl<'a> LibSQLDriver {
-    pub async fn new<'b>(
-        db_url: &String,
+impl LibSQLDriver {
+    pub async fn new(
+        db_url: &str,
         token: Option<String>,
         migrations_table: String,
         migrations_folder: String,

--- a/src/lib/database_drivers/maria.rs
+++ b/src/lib/database_drivers/maria.rs
@@ -283,70 +283,79 @@ impl DatabaseDriver for MariaDBDriver {
 
             let constraints: Vec<String> = sqlx::query(
                 r#"
-                    SELECT DISTINCT
+                    SELECT
                         CONCAT(
-                            'ALTER TABLE ', 
-                            TABLE_NAME, 
+                            'ALTER TABLE ',
+                            TABLE_NAME,
                             ' ADD CONSTRAINT ',
-                            CASE 
+                            CASE
                                 WHEN CONSTRAINT_NAME = 'PRIMARY' THEN 'PRIMARY KEY'
-                                WHEN INDEX_NAME != 'PRIMARY' THEN 'UNIQUE'
+                                WHEN INDEX_NAME != 'PRIMARY' AND INDEX_NAME IS NOT NULL THEN 'UNIQUE'
                                 ELSE 'FOREIGN KEY'
-                            END, 
-                            ' (', 
-                            COLUMN_NAME, 
-                            CASE 
-                                WHEN REFERENCED_TABLE_NAME IS NOT NULL THEN 
-                                    CONCAT(') REFERENCES ', REFERENCED_TABLE_NAME, ' (', REFERENCED_COLUMN_NAME, ')')
+                            END,
+                            ' (',
+                            GROUP_CONCAT(COLUMN_NAME ORDER BY ORDINAL_POSITION SEPARATOR ', '),
+                            CASE
+                                WHEN MAX(REFERENCED_TABLE_NAME) IS NOT NULL THEN
+                                    CONCAT(') REFERENCES ', MAX(REFERENCED_TABLE_NAME), ' (', GROUP_CONCAT(REFERENCED_COLUMN_NAME ORDER BY ORDINAL_POSITION SEPARATOR ', '), ')')
                                 ELSE ')'
-                            END, 
+                            END,
                             ';'
                         ) AS create_constraint_stmt,
                         TABLE_NAME
-                    FROM 
+                    FROM
                         (
-                        SELECT 
-                            TABLE_NAME, 
-                            COLUMN_NAME, 
-                            CONSTRAINT_NAME, 
-                            NULL AS INDEX_NAME, 
-                            NULL AS REFERENCED_TABLE_NAME, 
-                            NULL AS REFERENCED_COLUMN_NAME
-                        FROM 
+                        SELECT
+                            TABLE_NAME,
+                            COLUMN_NAME,
+                            CONSTRAINT_NAME,
+                            NULL AS INDEX_NAME,
+                            NULL AS REFERENCED_TABLE_NAME,
+                            NULL AS REFERENCED_COLUMN_NAME,
+                            ORDINAL_POSITION
+                        FROM
                             INFORMATION_SCHEMA.KEY_COLUMN_USAGE
-                        WHERE 
-                            TABLE_SCHEMA = ? 
+                        WHERE
+                            TABLE_SCHEMA = ?
                             AND CONSTRAINT_NAME = 'PRIMARY'
                         UNION ALL
-                        SELECT 
-                            TABLE_NAME, 
-                            COLUMN_NAME, 
-                            NULL AS CONSTRAINT_NAME, 
-                            INDEX_NAME, 
-                            NULL AS REFERENCED_TABLE_NAME, 
-                            NULL AS REFERENCED_COLUMN_NAME
-                        FROM 
+                        SELECT
+                            TABLE_NAME,
+                            COLUMN_NAME,
+                            NULL AS CONSTRAINT_NAME,
+                            INDEX_NAME,
+                            NULL AS REFERENCED_TABLE_NAME,
+                            NULL AS REFERENCED_COLUMN_NAME,
+                            SEQ_IN_INDEX AS ORDINAL_POSITION
+                        FROM
                             INFORMATION_SCHEMA.STATISTICS
-                        WHERE 
-                            TABLE_SCHEMA = ? 
+                        WHERE
+                            TABLE_SCHEMA = ?
+                            AND NON_UNIQUE = 0
                             AND INDEX_NAME != 'PRIMARY'
                         UNION ALL
-                        SELECT 
-                            TABLE_NAME, 
-                            COLUMN_NAME, 
-                            CONSTRAINT_NAME, 
-                            NULL AS INDEX_NAME, 
-                            REFERENCED_TABLE_NAME, 
-                            REFERENCED_COLUMN_NAME
-                        FROM 
+                        SELECT
+                            TABLE_NAME,
+                            COLUMN_NAME,
+                            CONSTRAINT_NAME,
+                            NULL AS INDEX_NAME,
+                            REFERENCED_TABLE_NAME,
+                            REFERENCED_COLUMN_NAME,
+                            ORDINAL_POSITION
+                        FROM
                             INFORMATION_SCHEMA.KEY_COLUMN_USAGE
-                        WHERE 
-                            TABLE_SCHEMA = ? 
+                        WHERE
+                            TABLE_SCHEMA = ?
                             AND REFERENCED_TABLE_NAME IS NOT NULL
-                        ORDER BY COLUMN_NAME asc
                         ) AS constraints
-                    ORDER BY 
-                        TABLE_NAME asc
+                    GROUP BY
+                        TABLE_NAME,
+                        CONSTRAINT_NAME,
+                        INDEX_NAME
+                    ORDER BY
+                        TABLE_NAME,
+                        CONSTRAINT_NAME,
+                        INDEX_NAME
                 "#,
                 )
                 .bind(&self.db_name)
@@ -366,24 +375,25 @@ impl DatabaseDriver for MariaDBDriver {
 
             let indexes: Vec<String> = sqlx::query(
                 r#"
-                    SELECT 
+                    SELECT
                         CONCAT(
-                            'CREATE INDEX ', 
-                            INDEX_NAME, 
-                            ' ON ', 
-                            TABLE_NAME, 
-                            ' (', 
-                            COLUMN_NAME, 
+                            'CREATE INDEX ',
+                            INDEX_NAME,
+                            ' ON ',
+                            TABLE_NAME,
+                            ' (',
+                            GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ', '),
                             ');'
                         ) AS create_index_stmt
-                    FROM 
+                    FROM
                         INFORMATION_SCHEMA.STATISTICS
-                    WHERE 
+                    WHERE
                         TABLE_SCHEMA = ?
-                    GROUP BY 
-                        TABLE_NAME, INDEX_NAME, COLUMN_NAME
-                    ORDER BY 
-                        TABLE_NAME, COLUMN_NAME asc
+                        AND INDEX_NAME != 'PRIMARY'
+                    GROUP BY
+                        TABLE_NAME, INDEX_NAME
+                    ORDER BY
+                        TABLE_NAME, INDEX_NAME
                 "#,
             )
             .bind(&self.db_name)

--- a/src/lib/database_drivers/maria.rs
+++ b/src/lib/database_drivers/maria.rs
@@ -18,8 +18,8 @@ pub struct MariaDBDriver {
     schema_file: String,
 }
 
-impl<'a> MariaDBDriver {
-    pub async fn new<'b>(
+impl MariaDBDriver {
+    pub async fn new(
         db_url: &str,
         database_name: &str,
         wait_timeout: Option<usize>,

--- a/src/lib/database_drivers/maria.rs
+++ b/src/lib/database_drivers/maria.rs
@@ -515,7 +515,8 @@ mod tests {
     #[test]
     fn test_generate_mariadb_migrations_table_query() {
         let table_name = "schema_migrations";
-        let expected = "CREATE TABLE IF NOT EXISTS `schema_migrations` (id VARCHAR(255) PRIMARY KEY)";
+        let expected =
+            "CREATE TABLE IF NOT EXISTS `schema_migrations` (id VARCHAR(255) PRIMARY KEY)";
         let result = generate_mariadb_migrations_table_query(table_name);
         assert_eq!(result, expected);
     }
@@ -760,7 +761,8 @@ mod tests {
     #[test]
     fn test_generate_mariadb_migrations_table_query_schema_qualified() {
         let table_name = "migrations.migrations";
-        let expected = "CREATE TABLE IF NOT EXISTS `migrations`.`migrations` (id VARCHAR(255) PRIMARY KEY)";
+        let expected =
+            "CREATE TABLE IF NOT EXISTS `migrations`.`migrations` (id VARCHAR(255) PRIMARY KEY)";
         let result = generate_mariadb_migrations_table_query(table_name);
         assert_eq!(result, expected);
     }

--- a/src/lib/database_drivers/mod.rs
+++ b/src/lib/database_drivers/mod.rs
@@ -3,7 +3,7 @@ use anyhow::bail;
 use serde::{Deserialize, Serialize};
 use std::future::Future;
 use std::pin::Pin;
-use std::usize;
+
 
 pub mod libsql;
 pub mod maria;
@@ -90,7 +90,7 @@ pub async fn new(
     match scheme {
         "http" | "https" | "libsql" => {
             let driver = libsql::LibSQLDriver::new(
-                &parsed_db_url.to_string(),
+                parsed_db_url.as_str(),
                 db_token,
                 migrations_table,
                 migrations_folder,
@@ -101,7 +101,7 @@ pub async fn new(
         }
         "turso" => {
             let driver = turso::TursoDriver::new(
-                &parsed_db_url.to_string(),
+                parsed_db_url.as_str(),
                 db_token,
                 migrations_table,
                 migrations_folder,

--- a/src/lib/database_drivers/mod.rs
+++ b/src/lib/database_drivers/mod.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 use std::future::Future;
 use std::pin::Pin;
 
-
 pub mod libsql;
 pub mod maria;
 pub mod mysql;

--- a/src/lib/database_drivers/mysql.rs
+++ b/src/lib/database_drivers/mysql.rs
@@ -515,7 +515,8 @@ mod tests {
     #[test]
     fn test_generate_mysql_migrations_table_query() {
         let table_name = "schema_migrations";
-        let expected = "CREATE TABLE IF NOT EXISTS `schema_migrations` (id VARCHAR(255) PRIMARY KEY)";
+        let expected =
+            "CREATE TABLE IF NOT EXISTS `schema_migrations` (id VARCHAR(255) PRIMARY KEY)";
         let result = generate_mysql_migrations_table_query(table_name);
         assert_eq!(result, expected);
     }
@@ -720,7 +721,8 @@ mod tests {
     #[test]
     fn test_generate_mysql_migrations_table_query_schema_qualified() {
         let table_name = "migrations.migrations";
-        let expected = "CREATE TABLE IF NOT EXISTS `migrations`.`migrations` (id VARCHAR(255) PRIMARY KEY)";
+        let expected =
+            "CREATE TABLE IF NOT EXISTS `migrations`.`migrations` (id VARCHAR(255) PRIMARY KEY)";
         let result = generate_mysql_migrations_table_query(table_name);
         assert_eq!(result, expected);
     }

--- a/src/lib/database_drivers/mysql.rs
+++ b/src/lib/database_drivers/mysql.rs
@@ -283,70 +283,79 @@ impl DatabaseDriver for MySQLDriver {
 
             let constraints: Vec<String> = sqlx::query(
                 r#"
-                    SELECT DISTINCT
+                    SELECT
                         CONCAT(
-                            'ALTER TABLE ', 
-                            TABLE_NAME, 
+                            'ALTER TABLE ',
+                            TABLE_NAME,
                             ' ADD CONSTRAINT ',
-                            CASE 
+                            CASE
                                 WHEN CONSTRAINT_NAME = 'PRIMARY' THEN 'PRIMARY KEY'
-                                WHEN INDEX_NAME != 'PRIMARY' THEN 'UNIQUE'
+                                WHEN INDEX_NAME != 'PRIMARY' AND INDEX_NAME IS NOT NULL THEN 'UNIQUE'
                                 ELSE 'FOREIGN KEY'
-                            END, 
-                            ' (', 
-                            COLUMN_NAME, 
-                            CASE 
-                                WHEN REFERENCED_TABLE_NAME IS NOT NULL THEN 
-                                    CONCAT(') REFERENCES ', REFERENCED_TABLE_NAME, ' (', REFERENCED_COLUMN_NAME, ')')
+                            END,
+                            ' (',
+                            GROUP_CONCAT(COLUMN_NAME ORDER BY ORDINAL_POSITION SEPARATOR ', '),
+                            CASE
+                                WHEN MAX(REFERENCED_TABLE_NAME) IS NOT NULL THEN
+                                    CONCAT(') REFERENCES ', MAX(REFERENCED_TABLE_NAME), ' (', GROUP_CONCAT(REFERENCED_COLUMN_NAME ORDER BY ORDINAL_POSITION SEPARATOR ', '), ')')
                                 ELSE ')'
-                            END, 
+                            END,
                             ';'
                         ) AS create_constraint_stmt,
                         TABLE_NAME
-                    FROM 
+                    FROM
                         (
-                        SELECT 
-                            TABLE_NAME, 
-                            COLUMN_NAME, 
-                            CONSTRAINT_NAME, 
-                            NULL AS INDEX_NAME, 
-                            NULL AS REFERENCED_TABLE_NAME, 
-                            NULL AS REFERENCED_COLUMN_NAME
-                        FROM 
+                        SELECT
+                            TABLE_NAME,
+                            COLUMN_NAME,
+                            CONSTRAINT_NAME,
+                            NULL AS INDEX_NAME,
+                            NULL AS REFERENCED_TABLE_NAME,
+                            NULL AS REFERENCED_COLUMN_NAME,
+                            ORDINAL_POSITION
+                        FROM
                             INFORMATION_SCHEMA.KEY_COLUMN_USAGE
-                        WHERE 
-                            TABLE_SCHEMA = ? 
+                        WHERE
+                            TABLE_SCHEMA = ?
                             AND CONSTRAINT_NAME = 'PRIMARY'
                         UNION ALL
-                        SELECT 
-                            TABLE_NAME, 
-                            COLUMN_NAME, 
-                            NULL AS CONSTRAINT_NAME, 
-                            INDEX_NAME, 
-                            NULL AS REFERENCED_TABLE_NAME, 
-                            NULL AS REFERENCED_COLUMN_NAME
-                        FROM 
+                        SELECT
+                            TABLE_NAME,
+                            COLUMN_NAME,
+                            NULL AS CONSTRAINT_NAME,
+                            INDEX_NAME,
+                            NULL AS REFERENCED_TABLE_NAME,
+                            NULL AS REFERENCED_COLUMN_NAME,
+                            SEQ_IN_INDEX AS ORDINAL_POSITION
+                        FROM
                             INFORMATION_SCHEMA.STATISTICS
-                        WHERE 
-                            TABLE_SCHEMA = ? 
+                        WHERE
+                            TABLE_SCHEMA = ?
+                            AND NON_UNIQUE = 0
                             AND INDEX_NAME != 'PRIMARY'
                         UNION ALL
-                        SELECT 
-                            TABLE_NAME, 
-                            COLUMN_NAME, 
-                            CONSTRAINT_NAME, 
-                            NULL AS INDEX_NAME, 
-                            REFERENCED_TABLE_NAME, 
-                            REFERENCED_COLUMN_NAME
-                        FROM 
+                        SELECT
+                            TABLE_NAME,
+                            COLUMN_NAME,
+                            CONSTRAINT_NAME,
+                            NULL AS INDEX_NAME,
+                            REFERENCED_TABLE_NAME,
+                            REFERENCED_COLUMN_NAME,
+                            ORDINAL_POSITION
+                        FROM
                             INFORMATION_SCHEMA.KEY_COLUMN_USAGE
-                        WHERE 
-                            TABLE_SCHEMA = ? 
+                        WHERE
+                            TABLE_SCHEMA = ?
                             AND REFERENCED_TABLE_NAME IS NOT NULL
-                        ORDER BY COLUMN_NAME asc
                         ) AS constraints
-                    ORDER BY 
-                        TABLE_NAME asc
+                    GROUP BY
+                        TABLE_NAME,
+                        CONSTRAINT_NAME,
+                        INDEX_NAME
+                    ORDER BY
+                        TABLE_NAME,
+                        CONSTRAINT_NAME,
+                        INDEX_NAME
                 "#,
                 )
                 .bind(&self.db_name)
@@ -366,24 +375,25 @@ impl DatabaseDriver for MySQLDriver {
 
             let indexes: Vec<String> = sqlx::query(
                 r#"
-                    SELECT 
+                    SELECT
                         CONCAT(
-                            'CREATE INDEX ', 
-                            INDEX_NAME, 
-                            ' ON ', 
-                            TABLE_NAME, 
-                            ' (', 
-                            COLUMN_NAME, 
+                            'CREATE INDEX ',
+                            INDEX_NAME,
+                            ' ON ',
+                            TABLE_NAME,
+                            ' (',
+                            GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ', '),
                             ');'
                         ) AS create_index_stmt
-                    FROM 
+                    FROM
                         INFORMATION_SCHEMA.STATISTICS
-                    WHERE 
+                    WHERE
                         TABLE_SCHEMA = ?
-                    GROUP BY 
-                        TABLE_NAME, INDEX_NAME, COLUMN_NAME
-                    ORDER BY 
-                        TABLE_NAME, COLUMN_NAME asc
+                        AND INDEX_NAME != 'PRIMARY'
+                    GROUP BY
+                        TABLE_NAME, INDEX_NAME
+                    ORDER BY
+                        TABLE_NAME, INDEX_NAME
                 "#,
             )
             .bind(&self.db_name)

--- a/src/lib/database_drivers/mysql.rs
+++ b/src/lib/database_drivers/mysql.rs
@@ -17,8 +17,8 @@ pub struct MySQLDriver {
     schema_file: String,
 }
 
-impl<'a> MySQLDriver {
-    pub async fn new<'b>(
+impl MySQLDriver {
+    pub async fn new(
         db_url: &str,
         database_name: &str,
         wait_timeout: Option<usize>,

--- a/src/lib/database_drivers/postgres.rs
+++ b/src/lib/database_drivers/postgres.rs
@@ -218,11 +218,12 @@ impl DatabaseDriver for PostgresDriver {
             let extensions: Vec<String> = sqlx::query(
                 r#"
                 SELECT
-                    'CREATE EXTENSION IF NOT EXISTS "' || extname || '" WITH SCHEMA public;' AS sql
+                    'CREATE EXTENSION IF NOT EXISTS "' || extname || '" WITH SCHEMA ' || nspname || ';' AS sql
                 FROM
                     pg_extension
+                JOIN pg_namespace ON pg_namespace.oid = pg_extension.extnamespace
                 WHERE
-                    (SELECT nspname FROM pg_namespace WHERE oid = extnamespace) = 'public'
+                    nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
                 ORDER BY extname ASC
                 "#,
             )
@@ -240,26 +241,26 @@ impl DatabaseDriver for PostgresDriver {
 
             let tables: Vec<String> = sqlx::query(
                 r#"
-                SELECT 
-                    'CREATE TABLE ' || t.table_name || E' (\n ' || 
-                    string_agg(c.column_name || ' ' || c.data_type || ' ' || 
-                                (CASE WHEN c.character_maximum_length IS NOT NULL 
-                                    THEN '(' || c.character_maximum_length || ')' 
-                                    ELSE '' END) || 
-                                (CASE WHEN c.is_nullable = 'NO' THEN ' NOT NULL' ELSE '' END), 
-                                E',\n ' ORDER BY c.column_name ASC) || 
+                SELECT
+                    'CREATE TABLE ' || t.table_schema || '."' || t.table_name || E'" (\n ' ||
+                    string_agg(c.column_name || ' ' || c.data_type || ' ' ||
+                                (CASE WHEN c.character_maximum_length IS NOT NULL
+                                    THEN '(' || c.character_maximum_length || ')'
+                                    ELSE '' END) ||
+                                (CASE WHEN c.is_nullable = 'NO' THEN ' NOT NULL' ELSE '' END),
+                                E',\n ' ORDER BY c.column_name ASC) ||
                     E'\n);' AS sql
-                FROM 
+                FROM
                     information_schema.columns c
-                JOIN 
-                    information_schema.tables t ON c.table_name = t.table_name
-                WHERE 
-                    t.table_schema = 'public' 
+                JOIN
+                    information_schema.tables t ON c.table_name = t.table_name AND c.table_schema = t.table_schema
+                WHERE
+                    t.table_schema NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
                     AND t.table_type = 'BASE TABLE'
-                GROUP BY 
-                    t.table_name
-                ORDER BY 
-                    t.table_name;
+                GROUP BY
+                    t.table_schema, t.table_name
+                ORDER BY
+                    t.table_schema, t.table_name;
                 "#,
             )
             .map(|row: PgRow| row.get("sql"))
@@ -276,14 +277,14 @@ impl DatabaseDriver for PostgresDriver {
 
             let views: Vec<String> = sqlx::query(
                 r#"
-                SELECT 
-                    'CREATE VIEW ' || table_name || ' AS\n' || view_definition || ';' AS sql
-                FROM 
+                SELECT
+                    'CREATE VIEW ' || table_schema || '."' || table_name || '" AS\n' || view_definition || ';' AS sql
+                FROM
                     information_schema.views
-                WHERE 
-                    table_schema = 'public'
-                ORDER BY 
-                    table_name ASC
+                WHERE
+                    table_schema NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+                ORDER BY
+                    table_schema, table_name ASC
                 "#,
             )
             .map(|row: PgRow| row.get("sql"))
@@ -303,23 +304,24 @@ impl DatabaseDriver for PostgresDriver {
                 SELECT
                     CASE
                         WHEN tc.constraint_type = 'PRIMARY KEY' THEN
-                            'ALTER TABLE ' || tc.table_name ||
-                            ' ADD CONSTRAINT ' || tc.constraint_name ||
-                            ' PRIMARY KEY (' || (SELECT string_agg(kcu2.column_name, ', ' ORDER BY kcu2.ordinal_position) FROM information_schema.key_column_usage kcu2 WHERE kcu2.constraint_name = tc.constraint_name AND kcu2.table_schema = 'public') || ');'
+                            'ALTER TABLE ' || tc.table_schema || '."' || tc.table_name ||
+                            '" ADD CONSTRAINT ' || tc.constraint_name ||
+                            ' PRIMARY KEY (' || (SELECT string_agg(kcu2.column_name, ', ' ORDER BY kcu2.ordinal_position) FROM information_schema.key_column_usage kcu2 WHERE kcu2.constraint_name = tc.constraint_name AND kcu2.table_schema = tc.table_schema) || ');'
                         WHEN tc.constraint_type = 'FOREIGN KEY' THEN
-                            'ALTER TABLE ' || tc.table_name ||
-                            ' ADD CONSTRAINT ' || tc.constraint_name ||
-                            ' FOREIGN KEY (' || (SELECT string_agg(kcu2.column_name, ', ' ORDER BY kcu2.ordinal_position) FROM information_schema.key_column_usage kcu2 WHERE kcu2.constraint_name = tc.constraint_name AND kcu2.table_schema = 'public') || ') REFERENCES ' ||
-                            (SELECT ccu2.table_name FROM information_schema.constraint_column_usage ccu2 WHERE ccu2.constraint_name = tc.constraint_name LIMIT 1) || '(' || (SELECT string_agg(kcu3.column_name, ', ' ORDER BY kcu3.ordinal_position) FROM information_schema.key_column_usage kcu3 WHERE kcu3.constraint_name = tc.constraint_name AND kcu3.table_schema = 'public') || ');'
+                            'ALTER TABLE ' || tc.table_schema || '."' || tc.table_name ||
+                            '" ADD CONSTRAINT ' || tc.constraint_name ||
+                            ' FOREIGN KEY (' || (SELECT string_agg(kcu2.column_name, ', ' ORDER BY kcu2.ordinal_position) FROM information_schema.key_column_usage kcu2 WHERE kcu2.constraint_name = tc.constraint_name AND kcu2.table_schema = tc.table_schema) || ') REFERENCES ' ||
+                            (SELECT ccu2.table_name FROM information_schema.constraint_column_usage ccu2 WHERE ccu2.constraint_name = tc.constraint_name LIMIT 1) || '(' || (SELECT string_agg(kcu3.column_name, ', ' ORDER BY kcu3.ordinal_position) FROM information_schema.key_column_usage kcu3 WHERE kcu3.constraint_name = tc.constraint_name AND kcu3.table_schema = tc.table_schema) || ');'
                         WHEN tc.constraint_type = 'UNIQUE' THEN
-                            'ALTER TABLE ' || tc.table_name ||
-                            ' ADD CONSTRAINT ' || tc.constraint_name ||
-                            ' UNIQUE (' || (SELECT string_agg(kcu2.column_name, ', ' ORDER BY kcu2.ordinal_position) FROM information_schema.key_column_usage kcu2 WHERE kcu2.constraint_name = tc.constraint_name AND kcu2.table_schema = 'public') || ');'
+                            'ALTER TABLE ' || tc.table_schema || '."' || tc.table_name ||
+                            '" ADD CONSTRAINT ' || tc.constraint_name ||
+                            ' UNIQUE (' || (SELECT string_agg(kcu2.column_name, ', ' ORDER BY kcu2.ordinal_position) FROM information_schema.key_column_usage kcu2 WHERE kcu2.constraint_name = tc.constraint_name AND kcu2.table_schema = tc.table_schema) || ');'
                         WHEN tc.constraint_type = 'CHECK' THEN
-                            'ALTER TABLE ' || tc.table_name ||
-                            ' ADD CONSTRAINT ' || tc.constraint_name ||
+                            'ALTER TABLE ' || tc.table_schema || '."' || tc.table_name ||
+                            '" ADD CONSTRAINT ' || tc.constraint_name ||
                             ' CHECK (' || cc.check_clause || ');'
                     END AS sql,
+                    tc.table_schema,
                     tc.table_name,
                     tc.constraint_name
                 FROM
@@ -327,13 +329,15 @@ impl DatabaseDriver for PostgresDriver {
                 LEFT JOIN
                     information_schema.check_constraints cc ON tc.constraint_name = cc.constraint_name
                 WHERE
-                    tc.table_schema = 'public'
+                    tc.table_schema NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
                 GROUP BY
+                    tc.table_schema,
                     tc.table_name,
                     tc.constraint_name,
                     tc.constraint_type,
                     cc.check_clause
                 ORDER BY
+                    tc.table_schema,
                     tc.table_name,
                     tc.constraint_name
                 "#,
@@ -352,14 +356,14 @@ impl DatabaseDriver for PostgresDriver {
 
             let indexes: Vec<String> = sqlx::query(
                 r#"
-                SELECT 
+                SELECT
                     indexdef AS sql
-                FROM 
+                FROM
                     pg_indexes
-                WHERE 
-                    schemaname = 'public'
-                ORDER BY 
-                    indexname ASC;
+                WHERE
+                    schemaname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+                ORDER BY
+                    schemaname, indexname ASC;
                 "#,
             )
             .map(|row: PgRow| row.get("sql"))
@@ -376,20 +380,20 @@ impl DatabaseDriver for PostgresDriver {
 
             let sequences: Vec<String> = sqlx::query(
                 r#"
-                SELECT 
-                    'CREATE SEQUENCE ' || sequence_name || 
-                    ' AS ' || data_type || 
-                    ' START WITH ' || start_value || 
-                    ' MINVALUE ' || minimum_value || 
-                    ' MAXVALUE ' || maximum_value || 
-                    ' INCREMENT BY ' || increment || 
+                SELECT
+                    'CREATE SEQUENCE ' || sequence_schema || '."' || sequence_name ||
+                    '" AS ' || data_type ||
+                    ' START WITH ' || start_value ||
+                    ' MINVALUE ' || minimum_value ||
+                    ' MAXVALUE ' || maximum_value ||
+                    ' INCREMENT BY ' || increment ||
                     ' CYCLE;' AS sql
-                FROM 
+                FROM
                     information_schema.sequences
-                WHERE 
-                    sequence_schema = 'public'
-                ORDER BY 
-                    sequence_name ASC;
+                WHERE
+                    sequence_schema NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+                ORDER BY
+                    sequence_schema, sequence_name ASC;
                 "#,
             )
             .map(|row: PgRow| row.get("sql"))
@@ -410,26 +414,21 @@ impl DatabaseDriver for PostgresDriver {
                     'COMMENT ON ' ||
                     CASE
                         WHEN pa.attnum > 0 THEN
-                            'COLUMN ' || pc.relname || '.' || pa.attname
+                            'COLUMN ' || n.nspname || '.' || pc.relname || '.' || pa.attname
                         ELSE
-                            'TABLE ' || pc.relname
+                            'TABLE ' || n.nspname || '.' || pc.relname
                     END ||
                     ' IS ' || pd.description || ';' AS sql
                 FROM
                     pg_class pc
+                    JOIN pg_namespace n ON n.oid = pc.relnamespace
                     JOIN pg_attribute pa ON pc.oid = pa.attrelid
                     LEFT JOIN pg_description pd ON pc.oid = pd.objoid AND pa.attnum = pd.objsubid
                 WHERE
-                    pc.relnamespace = (
-                        SELECT
-                            oid
-                        FROM
-                            pg_namespace
-                        WHERE
-                            nspname = 'public'
-                    )
+                    n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
                     AND pd.description IS NOT NULL
                 ORDER BY
+                    n.nspname,
                     pc.relname,
                     pa.attnum;
                 "#,

--- a/src/lib/database_drivers/postgres.rs
+++ b/src/lib/database_drivers/postgres.rs
@@ -300,40 +300,41 @@ impl DatabaseDriver for PostgresDriver {
 
             let constraints: Vec<String> = sqlx::query(
                 r#"
-                SELECT DISTINCT
-                    CASE 
-                        WHEN tc.constraint_type = 'PRIMARY KEY' THEN 
-                            'ALTER TABLE ' || tc.table_name || 
-                            ' ADD CONSTRAINT ' || tc.constraint_name || 
-                            ' PRIMARY KEY (' || kcu.column_name || ');'
-                        WHEN tc.constraint_type = 'FOREIGN KEY' THEN 
-                            'ALTER TABLE ' || tc.table_name || 
-                            ' ADD CONSTRAINT ' || tc.constraint_name || 
-                            ' FOREIGN KEY (' || kcu.column_name || ') REFERENCES ' || 
-                            ccu.table_name || '(' || ccu.column_name || ');'
-                        WHEN tc.constraint_type = 'UNIQUE' THEN 
-                            'ALTER TABLE ' || tc.table_name || 
-                            ' ADD CONSTRAINT ' || tc.constraint_name || 
-                            ' UNIQUE (' || kcu.column_name || ');'
-                        WHEN tc.constraint_type = 'CHECK' THEN 
-                            'ALTER TABLE ' || tc.table_name || 
-                            ' ADD CONSTRAINT ' || tc.constraint_name || 
+                SELECT
+                    CASE
+                        WHEN tc.constraint_type = 'PRIMARY KEY' THEN
+                            'ALTER TABLE ' || tc.table_name ||
+                            ' ADD CONSTRAINT ' || tc.constraint_name ||
+                            ' PRIMARY KEY (' || (SELECT string_agg(kcu2.column_name, ', ' ORDER BY kcu2.ordinal_position) FROM information_schema.key_column_usage kcu2 WHERE kcu2.constraint_name = tc.constraint_name AND kcu2.table_schema = 'public') || ');'
+                        WHEN tc.constraint_type = 'FOREIGN KEY' THEN
+                            'ALTER TABLE ' || tc.table_name ||
+                            ' ADD CONSTRAINT ' || tc.constraint_name ||
+                            ' FOREIGN KEY (' || (SELECT string_agg(kcu2.column_name, ', ' ORDER BY kcu2.ordinal_position) FROM information_schema.key_column_usage kcu2 WHERE kcu2.constraint_name = tc.constraint_name AND kcu2.table_schema = 'public') || ') REFERENCES ' ||
+                            (SELECT ccu2.table_name FROM information_schema.constraint_column_usage ccu2 WHERE ccu2.constraint_name = tc.constraint_name LIMIT 1) || '(' || (SELECT string_agg(kcu3.column_name, ', ' ORDER BY kcu3.ordinal_position) FROM information_schema.key_column_usage kcu3 WHERE kcu3.constraint_name = tc.constraint_name AND kcu3.table_schema = 'public') || ');'
+                        WHEN tc.constraint_type = 'UNIQUE' THEN
+                            'ALTER TABLE ' || tc.table_name ||
+                            ' ADD CONSTRAINT ' || tc.constraint_name ||
+                            ' UNIQUE (' || (SELECT string_agg(kcu2.column_name, ', ' ORDER BY kcu2.ordinal_position) FROM information_schema.key_column_usage kcu2 WHERE kcu2.constraint_name = tc.constraint_name AND kcu2.table_schema = 'public') || ');'
+                        WHEN tc.constraint_type = 'CHECK' THEN
+                            'ALTER TABLE ' || tc.table_name ||
+                            ' ADD CONSTRAINT ' || tc.constraint_name ||
                             ' CHECK (' || cc.check_clause || ');'
                     END AS sql,
-                    tc.table_name, 
+                    tc.table_name,
                     tc.constraint_name
-                FROM 
+                FROM
                     information_schema.table_constraints tc
-                JOIN 
-                    information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
-                LEFT JOIN 
-                    information_schema.constraint_column_usage ccu ON kcu.constraint_name = ccu.constraint_name
-                LEFT JOIN 
+                LEFT JOIN
                     information_schema.check_constraints cc ON tc.constraint_name = cc.constraint_name
-                WHERE 
+                WHERE
                     tc.table_schema = 'public'
-                ORDER BY 
-                    tc.table_name, 
+                GROUP BY
+                    tc.table_name,
+                    tc.constraint_name,
+                    tc.constraint_type,
+                    cc.check_clause
+                ORDER BY
+                    tc.table_name,
                     tc.constraint_name
                 "#,
             )

--- a/src/lib/database_drivers/postgres.rs
+++ b/src/lib/database_drivers/postgres.rs
@@ -512,7 +512,8 @@ mod tests {
     #[test]
     fn test_generate_postgres_migrations_table_query() {
         let table_name = "schema_migrations";
-        let expected = "CREATE TABLE IF NOT EXISTS \"schema_migrations\" (id VARCHAR(255) PRIMARY KEY)";
+        let expected =
+            "CREATE TABLE IF NOT EXISTS \"schema_migrations\" (id VARCHAR(255) PRIMARY KEY)";
         let result = generate_postgres_migrations_table_query(table_name);
         assert_eq!(result, expected);
     }
@@ -520,7 +521,8 @@ mod tests {
     #[test]
     fn test_generate_postgres_migrations_table_query_custom() {
         let table_name = "custom_migrations";
-        let expected = "CREATE TABLE IF NOT EXISTS \"custom_migrations\" (id VARCHAR(255) PRIMARY KEY)";
+        let expected =
+            "CREATE TABLE IF NOT EXISTS \"custom_migrations\" (id VARCHAR(255) PRIMARY KEY)";
         let result = generate_postgres_migrations_table_query(table_name);
         assert_eq!(result, expected);
     }

--- a/src/lib/database_drivers/postgres.rs
+++ b/src/lib/database_drivers/postgres.rs
@@ -18,8 +18,8 @@ pub struct PostgresDriver {
     schema_file: String,
 }
 
-impl<'a> PostgresDriver {
-    pub async fn new<'b>(
+impl PostgresDriver {
+    pub async fn new(
         db_url: &str,
         database_name: &str,
         wait_timeout: Option<usize>,

--- a/src/lib/database_drivers/sqlite.rs
+++ b/src/lib/database_drivers/sqlite.rs
@@ -105,11 +105,7 @@ impl DatabaseDriver for SqliteDriver {
             let table = utils::quote_identifier(&self.migrations_table, "\"");
             self.db
                 .execute(
-                    format!(
-                        "INSERT INTO {} (id) VALUES ('{}');",
-                        table, id,
-                    )
-                    .as_str(),
+                    format!("INSERT INTO {} (id) VALUES ('{}');", table, id,).as_str(),
                     params![],
                 )
                 .await?;

--- a/src/lib/database_drivers/sqlite.rs
+++ b/src/lib/database_drivers/sqlite.rs
@@ -16,8 +16,8 @@ pub struct SqliteDriver {
     schema_file: String,
 }
 
-impl<'a> SqliteDriver {
-    pub async fn new<'b>(
+impl SqliteDriver {
+    pub async fn new(
         db_url: &str,
         migrations_table: String,
         migrations_folder: String,

--- a/src/lib/database_drivers/turso.rs
+++ b/src/lib/database_drivers/turso.rs
@@ -16,15 +16,14 @@ pub struct TursoDriver {
 
 impl TursoDriver {
     pub async fn new(
-        db_url: &String,
+        db_url: &str,
         _token: Option<String>,
         migrations_table: String,
         migrations_folder: String,
         schema_file: String,
     ) -> Result<TursoDriver> {
-        // Parse the turso:// URL to extract the file path
-        let path = if db_url.starts_with("turso://") {
-            &db_url["turso://".len()..]
+        let path = if let Some(stripped) = db_url.strip_prefix("turso://") {
+            stripped
         } else {
             bail!("Invalid Turso URL scheme. Must start with turso://")
         };

--- a/src/lib/database_drivers/turso.rs
+++ b/src/lib/database_drivers/turso.rs
@@ -90,9 +90,7 @@ impl DatabaseDriver for TursoDriver {
 
             let mut stmt = self
                 .conn
-                .prepare(
-                    format!("SELECT id FROM {} ORDER BY id DESC;", table).as_str(),
-                )
+                .prepare(format!("SELECT id FROM {} ORDER BY id DESC;", table).as_str())
                 .await?;
 
             let mut rows = stmt.query(()).await?;
@@ -135,10 +133,7 @@ impl DatabaseDriver for TursoDriver {
         let fut = async move {
             let table = utils::quote_identifier(&self.migrations_table, "\"");
             self.conn
-                .execute(
-                    format!("DELETE FROM {} WHERE id = ?", table).as_str(),
-                    [id],
-                )
+                .execute(format!("DELETE FROM {} WHERE id = ?", table).as_str(), [id])
                 .await?;
             Ok(())
         };

--- a/src/lib/database_drivers/utils.rs
+++ b/src/lib/database_drivers/utils.rs
@@ -234,7 +234,10 @@ mod tests {
     #[test]
     fn test_quote_identifier_simple() {
         assert_eq!(quote_identifier("users", "\""), "\"users\"");
-        assert_eq!(quote_identifier("schema_migrations", "`"), "`schema_migrations`");
+        assert_eq!(
+            quote_identifier("schema_migrations", "`"),
+            "`schema_migrations`"
+        );
     }
 
     #[test]
@@ -251,10 +254,7 @@ mod tests {
 
     #[test]
     fn test_quote_identifier_multiple_dots() {
-        assert_eq!(
-            quote_identifier("a.b.c", "\""),
-            "\"a\".\"b\".\"c\""
-        );
+        assert_eq!(quote_identifier("a.b.c", "\""), "\"a\".\"b\".\"c\"");
     }
 
     #[test]

--- a/src/lib/test_utils/database_test_utils.rs
+++ b/src/lib/test_utils/database_test_utils.rs
@@ -86,17 +86,26 @@ pub fn generate_postgres_migrations_table_query(table_name: &str) -> String {
 
 /// Helper function to generate PostgreSQL INSERT migration query for testing
 pub fn generate_postgres_insert_migration_query(table_name: &str) -> String {
-    format!("INSERT INTO {} (id) VALUES ($1)", quote_identifier(table_name, "\""))
+    format!(
+        "INSERT INTO {} (id) VALUES ($1)",
+        quote_identifier(table_name, "\"")
+    )
 }
 
 /// Helper function to generate PostgreSQL DELETE migration query for testing
 pub fn generate_postgres_delete_migration_query(table_name: &str) -> String {
-    format!("DELETE FROM {} WHERE id = $1", quote_identifier(table_name, "\""))
+    format!(
+        "DELETE FROM {} WHERE id = $1",
+        quote_identifier(table_name, "\"")
+    )
 }
 
 /// Helper function to generate PostgreSQL SELECT migrations query for testing
 pub fn generate_postgres_select_migrations_query(table_name: &str) -> String {
-    format!("SELECT id FROM {} ORDER BY id DESC", quote_identifier(table_name, "\""))
+    format!(
+        "SELECT id FROM {} ORDER BY id DESC",
+        quote_identifier(table_name, "\"")
+    )
 }
 
 /// Helper function to validate wait timeout for testing
@@ -132,17 +141,26 @@ pub fn generate_mysql_migrations_table_query(table_name: &str) -> String {
 
 /// Helper function to generate MySQL INSERT migration query for testing
 pub fn generate_mysql_insert_migration_query(table_name: &str) -> String {
-    format!("INSERT INTO {} (id) VALUES (?)", quote_identifier(table_name, "`"))
+    format!(
+        "INSERT INTO {} (id) VALUES (?)",
+        quote_identifier(table_name, "`")
+    )
 }
 
 /// Helper function to generate MySQL DELETE migration query for testing
 pub fn generate_mysql_delete_migration_query(table_name: &str) -> String {
-    format!("DELETE FROM {} WHERE id = ?", quote_identifier(table_name, "`"))
+    format!(
+        "DELETE FROM {} WHERE id = ?",
+        quote_identifier(table_name, "`")
+    )
 }
 
 /// Helper function to generate MySQL SELECT migrations query for testing
 pub fn generate_mysql_select_migrations_query(table_name: &str) -> String {
-    format!("SELECT id FROM {} ORDER BY id DESC", quote_identifier(table_name, "`"))
+    format!(
+        "SELECT id FROM {} ORDER BY id DESC",
+        quote_identifier(table_name, "`")
+    )
 }
 
 /// Helper function to normalize MySQL localhost to 127.0.0.1 for testing
@@ -182,17 +200,26 @@ pub fn generate_mariadb_migrations_table_query(table_name: &str) -> String {
 
 /// Helper function to generate MariaDB INSERT migration query for testing
 pub fn generate_mariadb_insert_migration_query(table_name: &str) -> String {
-    format!("INSERT INTO {} (id) VALUES (?)", quote_identifier(table_name, "`"))
+    format!(
+        "INSERT INTO {} (id) VALUES (?)",
+        quote_identifier(table_name, "`")
+    )
 }
 
 /// Helper function to generate MariaDB DELETE migration query for testing
 pub fn generate_mariadb_delete_migration_query(table_name: &str) -> String {
-    format!("DELETE FROM {} WHERE id = ?", quote_identifier(table_name, "`"))
+    format!(
+        "DELETE FROM {} WHERE id = ?",
+        quote_identifier(table_name, "`")
+    )
 }
 
 /// Helper function to generate MariaDB SELECT migrations query for testing
 pub fn generate_mariadb_select_migrations_query(table_name: &str) -> String {
-    format!("SELECT id FROM {} ORDER BY id DESC", quote_identifier(table_name, "`"))
+    format!(
+        "SELECT id FROM {} ORDER BY id DESC",
+        quote_identifier(table_name, "`")
+    )
 }
 
 /// Helper function to normalize MariaDB localhost to 127.0.0.1 for testing

--- a/src/lib/utils.rs
+++ b/src/lib/utils.rs
@@ -34,7 +34,7 @@ pub fn get_local_migrations(folder: &PathBuf, ending: &str) -> Result<Vec<(i64, 
         })
         .collect::<Vec<(i64, PathBuf)>>();
 
-    sorted.sort_by(|a, b| a.0.cmp(&b.0));
+    sorted.sort_by_key(|a| a.0);
 
     Ok(sorted)
 }

--- a/tests/dump.rs
+++ b/tests/dump.rs
@@ -484,3 +484,136 @@ async fn test_dump_composite_primary_key_sqlite() -> Result<()> {
 
     Ok(())
 }
+
+async fn setup_multi_schema_postgres(database_url: &str) -> Result<()> {
+    let mut create_client = database_drivers::new(
+        database_url.to_string(),
+        None,
+        "schema_migrations".to_string(),
+        "./migrations".to_string(),
+        "schema.sql".to_string(),
+        Some(30),
+        false,
+    )
+    .await?;
+
+    create_client.create_database().await?;
+
+    drop(create_client);
+
+    let mut client = database_drivers::new(
+        database_url.to_string(),
+        None,
+        "schema_migrations".to_string(),
+        "./migrations".to_string(),
+        "schema.sql".to_string(),
+        Some(30),
+        true,
+    )
+    .await?;
+
+    let queries = vec![
+        "CREATE SCHEMA authz;",
+        r#"CREATE TABLE authz."group" (name TEXT PRIMARY KEY);"#,
+        r#"CREATE SEQUENCE authz."test";"#,
+        r#"CREATE TABLE public."group" (name TEXT PRIMARY KEY);"#,
+        r#"CREATE SEQUENCE public."test";"#,
+    ];
+
+    for query in queries {
+        client.execute(query, false).await?;
+    }
+
+    Ok(())
+}
+
+async fn run_multi_schema_dump_test(
+    database_url: &str,
+    schema_file: &str,
+    migrations_folder: &str,
+) -> Result<()> {
+    dump(
+        database_url.to_string(),
+        None,
+        "schema_migrations".to_string(),
+        migrations_folder.to_string(),
+        schema_file.to_string(),
+        Some(30),
+    )
+    .await?;
+
+    let schema_path = Path::new(migrations_folder).join(schema_file);
+    assert!(schema_path.exists(), "Schema file should be created");
+
+    let schema_content = fs::read_to_string(&schema_path)?;
+
+    assert!(
+        schema_content.contains("authz"),
+        "Schema should contain 'authz' references, got:\n{}",
+        schema_content
+    );
+
+    assert!(
+        schema_content.contains("public"),
+        "Schema should contain 'public' references, got:\n{}",
+        schema_content
+    );
+
+    let table_lines: Vec<&str> = schema_content
+        .lines()
+        .filter(|l| l.contains("CREATE TABLE") && l.contains("\"group\""))
+        .collect();
+
+    assert_eq!(
+        table_lines.len(),
+        2,
+        "Should have 2 CREATE TABLE lines for 'group' (one per schema), got {} lines:\n{}\nFull schema:\n{}",
+        table_lines.len(),
+        table_lines.join("\n"),
+        schema_content
+    );
+
+    let sequence_lines: Vec<&str> = schema_content
+        .lines()
+        .filter(|l| l.contains("CREATE SEQUENCE") && l.contains("\"test\""))
+        .collect();
+
+    assert_eq!(
+        sequence_lines.len(),
+        2,
+        "Should have 2 CREATE SEQUENCE lines for 'test' (one per schema), got {} lines:\n{}\nFull schema:\n{}",
+        sequence_lines.len(),
+        sequence_lines.join("\n"),
+        schema_content
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_dump_multi_schema_postgres() -> Result<()> {
+    let container = GenericImage::new("postgres", "18.0")
+        .with_exposed_port(5432.tcp())
+        .with_wait_for(WaitFor::message_on_stdout(
+            "database system is ready to accept connections",
+        ))
+        .with_env_var("POSTGRES_DB", "development")
+        .with_env_var("POSTGRES_USER", "postgres")
+        .with_env_var("POSTGRES_PASSWORD", "mysecretpassword")
+        .start()
+        .await
+        .expect("Failed to start postgres");
+    let host_port = container.get_host_port_ipv4(5432).await?;
+    let url = format!(
+        "postgres://postgres:mysecretpassword@localhost:{}/app?sslmode=disable",
+        host_port
+    );
+
+    let tmp_dir = TempDir::new()?;
+    let migrations_folder = tmp_dir.path().to_str().unwrap().to_string();
+    setup_multi_schema_postgres(&url).await?;
+    run_multi_schema_dump_test(&url, "postgres_multi_schema.sql", &migrations_folder).await?;
+
+    drop(container);
+    Ok(())
+}

--- a/tests/dump.rs
+++ b/tests/dump.rs
@@ -54,7 +54,11 @@ async fn setup_test_schema(database_url: &str) -> Result<()> {
     Ok(())
 }
 
-async fn run_dump_test(database_url: &str, schema_file: &str, migrations_folder: &str) -> Result<()> {
+async fn run_dump_test(
+    database_url: &str,
+    schema_file: &str,
+    migrations_folder: &str,
+) -> Result<()> {
     let result = dump(
         database_url.to_string(),
         None,
@@ -208,5 +212,275 @@ async fn test_dump_with_invalid_database_url() {
     )
     .await;
 
-    assert!(result.is_err(), "Dump should fail with invalid database URL");
+    assert!(
+        result.is_err(),
+        "Dump should fail with invalid database URL"
+    );
+}
+
+async fn setup_composite_pk_schema(database_url: &str) -> Result<()> {
+    let mut create_client = database_drivers::new(
+        database_url.to_string(),
+        None,
+        "schema_migrations".to_string(),
+        "./migrations".to_string(),
+        "schema.sql".to_string(),
+        Some(30),
+        false,
+    )
+    .await?;
+
+    if !database_url.starts_with("http://") && !database_url.starts_with("https://") {
+        create_client.create_database().await?;
+    }
+
+    drop(create_client);
+
+    let mut client = database_drivers::new(
+        database_url.to_string(),
+        None,
+        "schema_migrations".to_string(),
+        "./migrations".to_string(),
+        "schema.sql".to_string(),
+        Some(30),
+        true,
+    )
+    .await?;
+
+    let is_mysql = database_url.starts_with("mysql://") || database_url.starts_with("mariadb://");
+    let create_table = if is_mysql {
+        "CREATE TABLE fancy_pants (country VARCHAR(255), segment VARCHAR(255), slug VARCHAR(255), PRIMARY KEY (country, segment, slug));"
+    } else {
+        "CREATE TABLE fancy_pants (country TEXT, segment TEXT, slug TEXT, PRIMARY KEY (country, segment, slug));"
+    };
+
+    client.execute(create_table, false).await?;
+
+    Ok(())
+}
+
+async fn run_composite_pk_dump_test(
+    database_url: &str,
+    schema_file: &str,
+    migrations_folder: &str,
+) -> Result<()> {
+    dump(
+        database_url.to_string(),
+        None,
+        "schema_migrations".to_string(),
+        migrations_folder.to_string(),
+        schema_file.to_string(),
+        Some(30),
+    )
+    .await?;
+
+    let schema_path = Path::new(migrations_folder).join(schema_file);
+    assert!(schema_path.exists(), "Schema file should be created");
+
+    let schema_content = fs::read_to_string(&schema_path)?;
+
+    let is_sqlite = database_url.starts_with("sqlite://");
+
+    if is_sqlite {
+        let create_lines: Vec<&str> = schema_content
+            .lines()
+            .filter(|l| {
+                l.contains("CREATE TABLE") && l.contains("fancy_pants") && l.contains("PRIMARY KEY")
+            })
+            .collect();
+
+        assert_eq!(
+            create_lines.len(),
+            1,
+            "Should have exactly one CREATE TABLE line with PRIMARY KEY, got {} lines: {:?}",
+            create_lines.len(),
+            create_lines
+        );
+
+        let create_line = create_lines[0];
+        let pk_part = create_line
+            .split("PRIMARY KEY")
+            .nth(1)
+            .unwrap()
+            .split('(')
+            .nth(1)
+            .unwrap()
+            .split(')')
+            .next()
+            .unwrap();
+        let pk_columns: Vec<&str> = pk_part.split(',').map(|s| s.trim()).collect();
+
+        assert_eq!(
+            pk_columns.len(),
+            3,
+            "Composite primary key should have 3 columns, got {}: {:?}\nCREATE TABLE line: {}\nPK part: '{}'",
+            pk_columns.len(),
+            pk_columns,
+            create_line,
+            pk_part
+        );
+        assert!(
+            pk_columns.iter().any(|c| c.to_lowercase() == "country"),
+            "Should contain 'country', got: {:?}",
+            pk_columns
+        );
+        assert!(
+            pk_columns.iter().any(|c| c.to_lowercase() == "segment"),
+            "Should contain 'segment', got: {:?}",
+            pk_columns
+        );
+        assert!(
+            pk_columns.iter().any(|c| c.to_lowercase() == "slug"),
+            "Should contain 'slug', got: {:?}",
+            pk_columns
+        );
+        assert!(
+            pk_columns.iter().any(|c| c.to_lowercase() == "country"),
+            "Should contain 'country', got: {:?}",
+            pk_columns
+        );
+        assert!(
+            pk_columns.iter().any(|c| c.to_lowercase() == "segment"),
+            "Should contain 'segment', got: {:?}",
+            pk_columns
+        );
+        assert!(
+            pk_columns.iter().any(|c| c.to_lowercase() == "slug"),
+            "Should contain 'slug', got: {:?}",
+            pk_columns
+        );
+    } else {
+        let constraint_lines: Vec<&str> = schema_content
+            .lines()
+            .filter(|l| l.contains("fancy_pants") && l.contains("PRIMARY KEY"))
+            .collect();
+
+        assert_eq!(
+            constraint_lines.len(),
+            1,
+            "Should have exactly one PRIMARY KEY constraint line, got {} lines: {:?}\nFull schema:\n{}",
+            constraint_lines.len(),
+            constraint_lines,
+            schema_content
+        );
+
+        let constraint = constraint_lines[0];
+        let pk_part = constraint
+            .split("PRIMARY KEY")
+            .nth(1)
+            .unwrap()
+            .split('(')
+            .nth(1)
+            .unwrap()
+            .split(')')
+            .next()
+            .unwrap();
+        let pk_columns: Vec<&str> = pk_part.split(',').map(|s| s.trim()).collect();
+
+        assert_eq!(
+            pk_columns.len(),
+            3,
+            "Composite primary key should have 3 columns, got {}: {:?}",
+            pk_columns.len(),
+            pk_columns
+        );
+        assert!(pk_columns.contains(&"country"));
+        assert!(pk_columns.contains(&"segment"));
+        assert!(pk_columns.contains(&"slug"));
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_dump_composite_primary_key_postgres() -> Result<()> {
+    let container = GenericImage::new("postgres", "18.0")
+        .with_exposed_port(5432.tcp())
+        .with_wait_for(WaitFor::message_on_stdout(
+            "database system is ready to accept connections",
+        ))
+        .with_env_var("POSTGRES_DB", "development")
+        .with_env_var("POSTGRES_USER", "postgres")
+        .with_env_var("POSTGRES_PASSWORD", "mysecretpassword")
+        .start()
+        .await
+        .expect("Failed to start postgres");
+    let host_port = container.get_host_port_ipv4(5432).await?;
+    let url = format!(
+        "postgres://postgres:mysecretpassword@localhost:{}/app?sslmode=disable",
+        host_port
+    );
+
+    let tmp_dir = TempDir::new()?;
+    let migrations_folder = tmp_dir.path().to_str().unwrap().to_string();
+    setup_composite_pk_schema(&url).await?;
+    run_composite_pk_dump_test(&url, "postgres_composite_pk_schema.sql", &migrations_folder)
+        .await?;
+
+    drop(container);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_dump_composite_primary_key_mysql() -> Result<()> {
+    let container = GenericImage::new("mysql", "latest")
+        .with_exposed_port(3306.tcp())
+        .with_wait_for(WaitFor::Log(
+            LogWaitStrategy::stdout_or_stderr("ready for connections").with_times(2),
+        ))
+        .with_env_var("MYSQL_ROOT_PASSWORD", "password")
+        .with_env_var("MYSQL_DATABASE", "development")
+        .start()
+        .await
+        .expect("Failed to start mysql");
+    let host_port = container.get_host_port_ipv4(3306).await?;
+    let url = format!("mysql://root:password@localhost:{}/app", host_port);
+
+    let tmp_dir = TempDir::new()?;
+    let migrations_folder = tmp_dir.path().to_str().unwrap().to_string();
+    setup_composite_pk_schema(&url).await?;
+    run_composite_pk_dump_test(&url, "mysql_composite_pk_schema.sql", &migrations_folder).await?;
+
+    drop(container);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_dump_composite_primary_key_mariadb() -> Result<()> {
+    let container = GenericImage::new("mariadb", "11.1.3")
+        .with_exposed_port(3306.tcp())
+        .with_wait_for(WaitFor::Log(
+            LogWaitStrategy::stdout_or_stderr("ready for connections").with_times(2),
+        ))
+        .with_env_var("MARIADB_ROOT_PASSWORD", "password")
+        .with_env_var("MARIADB_DATABASE", "development")
+        .start()
+        .await
+        .expect("Failed to start mariadb");
+    let host_port = container.get_host_port_ipv4(3306).await?;
+    let url = format!("mariadb://root:password@localhost:{}/app", host_port);
+
+    let tmp_dir = TempDir::new()?;
+    let migrations_folder = tmp_dir.path().to_str().unwrap().to_string();
+    setup_composite_pk_schema(&url).await?;
+    run_composite_pk_dump_test(&url, "mariadb_composite_pk_schema.sql", &migrations_folder).await?;
+
+    drop(container);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_dump_composite_primary_key_sqlite() -> Result<()> {
+    let tmp_dir = TempDir::new()?;
+    let db_file = tmp_dir.path().join("test_composite_pk.sqlite");
+    File::create(&db_file)?;
+
+    let database_url = format!("sqlite://{}", db_file.to_str().unwrap());
+    let schema_file = "sqlite_composite_pk_schema.sql";
+    let migrations_folder = tmp_dir.path().to_str().unwrap().to_string();
+
+    setup_composite_pk_schema(&database_url).await?;
+    run_composite_pk_dump_test(&database_url, schema_file, &migrations_folder).await?;
+
+    Ok(())
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -74,8 +74,7 @@ async fn test_migrate(database: Database, db_url: &str, migrations_table: &str) 
     let tmp_dir = TempDir::new()?;
     let migration_folder_string = tmp_dir.path().to_str().unwrap().to_string();
     let database_wait_timeout = 30;
-    let database_schema_file =
-        env::var("DATABASE_SCHEMA_FILE").unwrap_or("schema.sql".to_string());
+    let database_schema_file = env::var("DATABASE_SCHEMA_FILE").unwrap_or("schema.sql".to_string());
 
     generate_test_migrations(&migration_folder_string)?;
 
@@ -303,7 +302,9 @@ async fn test_migrate_sqlite() {
     let path = std::path::Path::new(&filename);
     File::create(path).unwrap();
     let url = format!("sqlite://{}", path.to_str().unwrap());
-    test_migrate(Database::SQLite, &url, "schema_migrations").await.unwrap();
+    test_migrate(Database::SQLite, &url, "schema_migrations")
+        .await
+        .unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
# Improve output of foreign keys for Maria, mysql and postgres
Fixes #291 

Instead of joining the keys did we print 1 key per line. This fixes that problem

# postgres: Add support for multiple schema and not only public schema

Fixes #290 